### PR TITLE
Use logging instead of print statements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,12 @@ __pycache__/
 # C extensions
 *.so
 
+# Slurm output files
+*.out
+
+# Torch checkpoints
+*.pth
+
 # Distribution / packaging
 .Python
 build/

--- a/anml.py
+++ b/anml.py
@@ -1,10 +1,12 @@
+import logging
+from pathlib import Path
+
+import higher
+import numpy as np
 import torch
 from torch.nn.functional import cross_entropy
 from torch.nn.init import kaiming_normal_
 from torch.optim import SGD, Adam
-import higher
-import numpy as np
-from pathlib import Path
 
 from model import ANML
 from utils import Log
@@ -19,7 +21,9 @@ def lobotomize(layer, class_num):
 def train(rln, nm, mask, inner_lr=1e-1, outer_lr=1e-3, its=30000, device="cuda"):
 
     log = Log(f"{rln}_{nm}_{mask}_ANML")
+    logging.info("Loading Omniglot data into memory...")
     omni_sampler = OmniSampler(root="../data/omni")
+    logging.info("... done.")
 
     anml = ANML(rln, nm, mask).to(device)
 

--- a/train_omni.py
+++ b/train_omni.py
@@ -1,4 +1,5 @@
 import argparse
+import logging
 import os
 import sys
 
@@ -6,6 +7,9 @@ import torch
 from torch import manual_seed
 
 from anml import train
+
+logging.basicConfig(level=logging.INFO, format='[%(asctime)s] [%(levelname)s] %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
+
 
 if __name__ == "__main__":
     # Training settings
@@ -44,11 +48,13 @@ if __name__ == "__main__":
     if device is None:
         device = "cuda" if torch.cuda.is_available() else "cpu"
     elif device == "cuda" and not torch.cuda.is_available():
-        print("Torch says CUDA is not available. Remove it from your command to proceed on CPU.", file=sys.stderr)
+        logging.error("Torch says CUDA is not available. Remove it from your command to proceed on CPU.")
         sys.exit(os.EX_UNAVAILABLE)
+    logging.info(f"Using device: {device}")
 
     manual_seed(args.seed)
 
+    logging.info("Commencing training.")
     train(
         args.rln,
         args.nm,

--- a/utils.py
+++ b/utils.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 from time import time, strftime, gmtime
 from torch import save
@@ -32,9 +33,7 @@ class Log:
                 end = time()
                 elapsed = end - self.start
                 self.start = end
-                print(
-                    f"{it}: {loss.item():.3f} | {acc:.3f} ({strftime('%H:%M:%S', gmtime(elapsed))})"
-                )
+                logging.info(f"{it}: {loss.item():.3f} | {acc:.3f} ({strftime('%H:%M:%S', gmtime(elapsed))})")
 
             if it % self.save_freq == 0:
                 save(model.state_dict(), f"trained_anmls/{self.name}-{it}.pth")


### PR DESCRIPTION
This flushes print statements to the log more regularly to let us view progress when running in slurm, and also adds convenient timestamps to the messages.

Also added a couple new file types to ignore.